### PR TITLE
flake8の導入

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .git,__pycache__
+max-line-length = 119

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 django = "*"
+flake8 = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "627ef89f247ecee27e9ef0dabe116108d09c47abf171c900a8817befa64f9dd2"
+            "sha256": "eb79fa3bc5c754a097fe331bd89ad50caca705b993cda157a16b90b645f29310"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,42 @@
             ],
             "index": "pypi",
             "version": "==2.1.7"
+        },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:6d8c66a65635d46d54de59b027a1dda40abbe2275b3164b634835ac9c13fd048",
+                "sha256:6eab21c6e34df2c05416faa40d0c59963008fff29b6f0ccfe8fa28152ab3e383"
+            ],
+            "index": "pypi",
+            "version": "==3.7.6"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:5e8c00e30c464c99e0b501dc160b13a14af7f27d4dffb529c556e30a159e231d",
+                "sha256:f277f9ca3e55de669fba45b7393a1449009cff5a37d1af10ebb76c52765269cd"
+            ],
+            "version": "==2.1.0"
         },
         "pytz": {
             "hashes": [


### PR DESCRIPTION
## 導入理由

### コードチェックツールの比較

コードチェックツールが欲しいものの、沢山あり過ぎて正直どれを選んでいいか悩む。
この辺とかこの辺の記事を眺めて、色々試行錯誤していた。

* [About style guide of python and linter tool. pep8, pyflakes, flake8, haking, Pylint.](https://blog.sideci.com/about-style-guide-of-python-and-linter-tool-pep8-pyflakes-flake8-haking-pyling-7fdbe163079d)
* [Pythonのスタイルガイドとそれを守るための各種Lint・解析ツール5種まとめ！ - Sider Blog](https://blog-ja.sideci.com/entry/python-lint-pickup-5tools)


### Django公式はflake8

[django_setup.cfg at 2.1.7 · django_django](https://github.com/django/django/blob/2.1.7/setup.cfg#L5)
```
[flake8]
exclude = build,.git,.tox,./django/utils/six.py,./django/conf/app_template/*,./tests/.env
ignore = W504,W601
max-line-length = 119
```

実際、```django-admin.py startproject config .```で作成した```config/settings.py```ファイルでは以下のようにE501が発生する。
```bash
./config/settings.py:89:80: E501 line too long (91 > 79 characters)
./config/settings.py:92:80: E501 line too long (81 > 79 characters)
./config/settings.py:95:80: E501 line too long (82 > 79 characters)
./config/settings.py:98:80: E501 line too long (83 > 79 characters)
```

今後、設定に変更があった場合に動きやすいのはflake8と判断した。


## 導入手順

### flake8をインストールする
```bash
pipenv install flake8
```


### flake8の設定ファイルを作成する

Configuring Flake8
http://flake8.pycqa.org/en/3.7.6/user/configuration.html
```
[flake8]
ignore = D203
exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
max-complexity = 10
```

必要になった時に必要なものを追加していくスタイルにしたいので最低限の設定を書くに留めた。