### PR TITLE
django-debug-toolbarの導入

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 django = "*"
 flake8 = "*"
 django-markdownx = "*"
+django-debug-toolbar = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c749fc266677971c969f89057dfb82940e5c46d727b8a4749554cbaef02c632d"
+            "sha256": "2fb33ec7aff0ff3a09e9a9d12e2498be5d60b3504ab099d0af5ed626a58fd009"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,14 @@
             ],
             "index": "pypi",
             "version": "==2.1.7"
+        },
+        "django-debug-toolbar": {
+            "hashes": [
+                "sha256:89d75b60c65db363fb24688d977e5fbf0e73386c67acf562d278402a10fc3736",
+                "sha256:c2b0134119a624f4ac9398b44f8e28a01c7686ac350a12a74793f3dd57a9eea0"
+            ],
+            "index": "pypi",
+            "version": "==1.11"
         },
         "django-markdownx": {
             "hashes": [
@@ -116,6 +124,13 @@
                 "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
             ],
             "version": "==2018.9"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec",
+                "sha256:d9cf190f51cbb26da0412247dfe4fb5f4098edb73db84e02f9fc21fdca31fed4"
+            ],
+            "version": "==0.2.4"
         }
     },
     "develop": {}

--- a/config/settings.py
+++ b/config/settings.py
@@ -130,3 +130,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+
+# Django Debug Toolbar — Django Debug Toolbar 1.11 documentation
+# https://django-debug-toolbar.readthedocs.io/en/latest/index.html
+SHOW_COLLAPSED = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -25,6 +25,10 @@ SECRET_KEY = '_9*-fb@s9o_m$-0(o_a_ogv6992khe=-@1rku406b!8iu*%z(c'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+INTERNAL_IPS = [
+    '10.0.2.2',  # VirtualBox default gateway IP address
+]
+
 ALLOWED_HOSTS = []
 
 
@@ -41,6 +45,7 @@ INSTALLED_APPS = [
     # Django Practice
     'pages',
     'markdownx',
+    'debug_toolbar',
 ]
 
 MIDDLEWARE = [
@@ -51,6 +56,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
 
 ROOT_URLCONF = 'config.urls'

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 
@@ -21,3 +22,9 @@ urlpatterns = [
     path('markdownx/', include('markdownx.urls')),
     path('', include('pages.urls')),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        path('__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns


### PR DESCRIPTION
## 導入理由

### おすすめ

SymfonyのWeb Debug Toolbarは便利過ぎた。
Djangoには標準装備されていないが、上記ライブラリを導入すると表示できる。

* [My essential django package list — _var_](https://spapas.github.io/2017/10/11/essential-django-packages/)
* [Django のおすすめライブラリ - Qiita](https://qiita.com/odoku/items/90ebec6657c736c90f93#django-debug-toolbar)
> 脳死で入れといておk。


## 導入手順

### django-debug-toolbarをインストールする

```bash
pipenv install django-debug-toolbar
```


### pipenv install django-debug-toolbarを設定する

* [Installation — Django Debug Toolbar 1.11 documentation](https://django-debug-toolbar.readthedocs.io/en/latest/installation.html)

#### Internal IPs

Vagrant + VirtualBox環境では追加の設定が必要なので注意。


### django-debug-toolbarをカスタマイズする

* [Configuration — Django Debug Toolbar 1.11 documentation](https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html)

表示順、表示非表示切替などが可能。今回は変更なし。
```SHOW_COLLAPSED```でツールバーの表示デフォルトを折り畳んだ状態に変更。

