### PR TITLE
django-bootstrap4の導入

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ django = "*"
 flake8 = "*"
 django-markdownx = "*"
 django-debug-toolbar = "*"
+django-bootstrap4 = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2fb33ec7aff0ff3a09e9a9d12e2498be5d60b3504ab099d0af5ed626a58fd009"
+            "sha256": "11e83949d21aafff1682f82a3238668a695c0dd3ccc7e545b34484ee4c001506"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,13 @@
             ],
             "index": "pypi",
             "version": "==2.1.7"
+        },
+        "django-bootstrap4": {
+            "hashes": [
+                "sha256:32ffee49c4c8ca7df543aac8733a5d45ad304078f920a0167819525bd33a955a"
+            ],
+            "index": "pypi",
+            "version": "==0.0.7"
         },
         "django-debug-toolbar": {
             "hashes": [

--- a/config/settings.py
+++ b/config/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     # Django Practice
     'pages',
     'markdownx',
+    'bootstrap4',
     'debug_toolbar',
 ]
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,3 +1,4 @@
+{% load bootstrap4 %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -5,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{% block title %}{% endblock %}</title>
+    {% bootstrap_css %}
 </head>
 <body>
 {% block content %}{% endblock %}
+{% bootstrap_javascript jquery="full" %}
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{% block title %}{% endblock %}</title>
     {% bootstrap_css %}
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css"
+          integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr"
+          crossorigin="anonymous">
 </head>
 <body>
 {% block content %}{% endblock %}


### PR DESCRIPTION
## 導入理由

### DjangoとBootstrapの練習をする

CSSその他諸々は凝ってしまうので考えない・自分で書かない。

チュートリアルや入門書、しばしば業務でも見かけるので練習。

BootstrapとFont Awesomeはフォームと合体すると割と鬼門なので練習。


## 導入手順

### django-bootstrap4のインストールと設定をする

```bash
pipenv install django-bootstrap4
```

* django-bootstrap4 0.0.7 documentation
  * [Installation](https://django-bootstrap4.readthedocs.io/en/latest/installation.html)
  * [Quickstart](https://django-bootstrap4.readthedocs.io/en/latest/quickstart.html)

無難に```{% bootstrap_javascript jquery="full" %}```。


### Font Awesomeの設定をする

公式ドキュメントのMigrationからリンクで飛ぶと、

* [zostera_django-fa_ Font Awesome for Django](https://github.com/zostera/django-fa)

> DEPRECATION NOTICE

↓使って下さいと言われる。

* [zostera_django-icons_ Icons for Django](https://github.com/zostera/django-icons)

内容は<i>タグが簡単に書けるというもの。

正直使ってみないとdjango-bootstrap4との相性などが分からない。
公式からCSSのみ追加して様子を見る。

* Font Awesome
  * [Start](https://fontawesome.com/start)

